### PR TITLE
Fix deprecation warning for replaceChars

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -263,7 +263,7 @@ let
 
       crateName="$(
         remarshal -if toml -of json Cargo.original.toml \
-        | jq -r 'if .lib."name" then .lib."name" else "${replaceChars ["-"] ["_"] name}" end' \
+        | jq -r 'if .lib."name" then .lib."name" else "${replaceStrings ["-"] ["_"] name}" end' \
       )"
 
       . ${./mkcrate-utils.sh}


### PR DESCRIPTION
Just a one word fix to `replaceChars` with `replaceStrings` and get rid of this warning on every build:

```
trace: warning: replaceChars is a deprecated alias of replaceStrings, replace usages of it with replaceStrings.
```