### PR TITLE
Fix use of `overlays.default` for rust-overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
   
   outputs = inputs: with inputs;
     let
-      overlays = import ./overlay (rust-overlay.overlay);
+      overlays = import ./overlay (rust-overlay.overlays.default);
       combinedOverlay = overlays.combined;
 
     in flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
Fix warning 

```
trace: warning: rust-overlay's flake output `overlay` is deprecated in favor of `overlays.default` for Nix >= 2.7
```